### PR TITLE
Namespace 'userId' and 'organizationId' constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   },
   "devDependencies": {
     "prisma": "^4.11.0"
+  },
+  "prisma": {
+    "seed": "node prisma/seed.js"
   }
 }

--- a/prisma/migrations/20230319212545_namespace_has_atleast_one_org_or_user/migration.sql
+++ b/prisma/migrations/20230319212545_namespace_has_atleast_one_org_or_user/migration.sql
@@ -1,0 +1,3 @@
+-- This is an empty migration.
+
+ALTER TABLE "Namespace" ADD CONSTRAINT "ensure_userId_or_orgId_exists" CHECK(num_nonnulls(("organizationId"), ("userId")) = 1);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,8 @@ model Organization {
   organizationInvitationss OrganizationInvitation[]
 }
 
+// Note: 20230319212545_namespace_has_atleast_one_org_or_user:
+// This ensures that 'userId' or 'organizationId' must be set. A row with both fields set or non set cannot exsist in the table.
 model Namespace {
   id   String @id @default(cuid())
   name String @unique @default(cuid())

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,87 @@
+const { PrismaClient } = require('@prisma/client')
+const prisma = new PrismaClient()
+
+async function main() {
+  const alice = await prisma.user.upsert({
+    where: { email: 'alice@prisma.io' },
+    update: {},
+    create: {
+      email: 'alice@prisma.io',
+      name: 'Alice',
+      username: 'Alice',
+    },
+  })
+
+  const bob = await prisma.user.upsert({
+    where: { email: 'bob@prisma.io' },
+    update: {},
+    create: {
+      email: 'bob@prisma.io',
+      name: 'Bob',
+      username: 'Bob',
+    },
+  })
+
+  // return await prisma.organization
+  // .create({
+  //   data: {
+  //     name,
+  //     userId: session.user.id,
+      // namespace: {
+      //   create: {
+      //     name
+      //   }
+      // }
+  //   }
+  // })
+
+  console.log({ alice, bob })
+  console.log()
+
+
+  // const find = await prisma.organization.findMany({
+  //   where: {
+  //     name: "3",
+  //   },
+  // })
+  const [deleteOrgs, newOrg] = await prisma.$transaction([
+    prisma.organization.deleteMany({ where: { name: 'AliceOrg'} }),
+    prisma.organization.create({
+      data: { 
+        name: 'AliceOrg',
+        userId: alice.id,
+        namespace: {
+          create: {
+            name: 'AliceOrg'
+          }
+        }}
+    })
+  ])
+
+  console.log("newOrg:")
+  console.log(newOrg)
+  console.log()
+
+  // NOTE: THIS SHOULD FAIL:
+
+  // const result = await prisma.namespace.update({
+  //   where: {
+  //     name: 'AliceOrg',
+  //   },
+  //   data: { 
+  //     organizationId: null,
+  //   }
+  // })
+
+  // console.log("result:")
+  // console.log(result)
+}
+main()
+  .then(async () => {
+    await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
+  })


### PR DESCRIPTION
This PR ensures that the Namespace must have at least a userId or organizationId value set. The table is not permitted to have both values set or none of them set, there has to be 1.