### PR TITLE
Fix/backend user creation

### DIFF
--- a/src/pages/api/user/index.js
+++ b/src/pages/api/user/index.js
@@ -53,24 +53,28 @@ export default async function handler(req, res) {
 
     console.log("Session", JSON.stringify(session, null, 2))
 
-    // if (true) {
-    //   console.log(token)
-    //   console.log()
-    //   console.log("Stringify", JSON.stringify(token))
-    //   const options = token.payload.session.options
-    //   setCookie(NEXT_AUTH_SESSION_COOKIE, token.payload.session.value, { req, res, options })
-    //   setCookie(NEW_USER_COOKIE, "", { req, res, maxAge: -1 })
-    //   console.log("Are we here?")
-    //   return res.status(200).json({ error: "success" })
-    // }
-
-    return await prisma.namespace
-      .create({
+    return await prisma.user
+      .update({
+        where: {
+          id: session.user.id
+        },
         data: {
-          name,
-          userId: session.user.id
+          username: name,
+          namespace: {
+            create: {
+              name: name
+            }
+          }
         }
       })
+      // return await prisma.namespace
+      //   .create({
+      //     data: {
+      //       username: name,
+      //       name: name,
+      //       userId: session.user.id
+      //     }
+      //   })
       .then((result) => {
         console.log("API RESULT: ", result)
         // setCookie(NEXT_AUTH_SESSION_COOKIE, decoded.session, { req, res })

--- a/src/pages/api/user/index.js
+++ b/src/pages/api/user/index.js
@@ -67,22 +67,10 @@ export default async function handler(req, res) {
           }
         }
       })
-      // return await prisma.namespace
-      //   .create({
-      //     data: {
-      //       username: name,
-      //       name: name,
-      //       userId: session.user.id
-      //     }
-      //   })
+
       .then((result) => {
-        console.log("API RESULT: ", result)
-        // setCookie(NEXT_AUTH_SESSION_COOKIE, decoded.session, { req, res })
-        // setCookie(NEW_USER_COOKIE, "", { req, res, maxAge: -1 })
-        // setCookie(NEXT_AUTH_SESSION_COOKIE, token.payload.session.value, { req, res, options })
         setCookie(NEW_USER_COOKIE, "", { req, res, maxAge: -1 })
-        console.log("Are we here?")
-        return res.redirect("/")
+        return res.status(200).json({ result: result })
       })
       .catch((err) => {
         // TODO: Check individual error codes from prisma. Check if the name already exists, if the user already has a namespace, etc


### PR DESCRIPTION
Properly sets the username field in the User table upon user creation. This also fixed the issue where names from 3rd party sites (Google, Github) were overridden.