### PR TITLE
Prisma member model refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@headlessui/react": "^1.7.13",
         "@next-auth/prisma-adapter": "^1.0.5",
-        "@prisma/client": "^4.12.0",
+        "@prisma/client": "^4.13.0",
         "@radix-ui/colors": "^0.1.8",
         "@radix-ui/react-avatar": "^1.0.2",
         "@radix-ui/react-dialog": "^1.0.3",
@@ -58,7 +58,7 @@
         "@types/uuid": "^9.0.1",
         "autoprefixer": "^10.4.14",
         "postcss": "^8.4.21",
-        "prisma": "^4.12.0",
+        "prisma": "^4.13.0",
         "tailwindcss": "^3.2.7",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.3"
@@ -593,12 +593,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.12.0.tgz",
-      "integrity": "sha512-j9/ighfWwux97J2dS15nqhl60tYoH8V0IuSsgZDb6bCFcQD3fXbXmxjYC8GHhIgOk3lB7Pq+8CwElz2MiDpsSg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.13.0.tgz",
+      "integrity": "sha512-YaiiICcRB2hatxsbnfB66uWXjcRw3jsZdlAVxmx0cFcTc/Ad/sKdHCcWSnqyDX47vAewkjRFwiLwrOUjswVvmA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7"
+        "@prisma/engines-version": "4.13.0-50.1e7af066ee9cb95cf3a403c78d9aab3e6b04f37a"
       },
       "engines": {
         "node": ">=14.17"
@@ -613,16 +613,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.12.0.tgz",
-      "integrity": "sha512-0alKtnxhNB5hYU+ymESBlGI4b9XrGGSdv7Ud+8TE/fBNOEhIud0XQsAR+TrvUZgS4na5czubiMsODw0TUrgkIA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.13.0.tgz",
+      "integrity": "sha512-HrniowHRZXHuGT9XRgoXEaP2gJLXM5RMoItaY2PkjvuZ+iHc0Zjbm/302MB8YsPdWozAPHHn+jpFEcEn71OgPw==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7.tgz",
-      "integrity": "sha512-JIHNj5jlXb9mcaJwakM0vpgRYJIAurxTUqM0iX0tfEQA5XLZ9ONkIckkhuAKdAzocZ+80GYg7QSsfpjg7OxbOA=="
+      "version": "4.13.0-50.1e7af066ee9cb95cf3a403c78d9aab3e6b04f37a",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.13.0-50.1e7af066ee9cb95cf3a403c78d9aab3e6b04f37a.tgz",
+      "integrity": "sha512-fsQlbkhPJf08JOzKoyoD9atdUijuGBekwoOPZC3YOygXEml1MTtgXVpnUNchQlRSY82OQ6pSGQ9PxUe4arcSLQ=="
     },
     "node_modules/@radix-ui/colors": {
       "version": "0.1.8",
@@ -5228,13 +5228,13 @@
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
     },
     "node_modules/prisma": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.12.0.tgz",
-      "integrity": "sha512-xqVper4mbwl32BWzLpdznHAYvYDWQQWK2tBfXjdUD397XaveRyAP7SkBZ6kFlIg8kKayF4hvuaVtYwXd9BodAg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.13.0.tgz",
+      "integrity": "sha512-L9mqjnSmvWIRCYJ9mQkwCtj4+JDYYTdhoyo8hlsHNDXaZLh/b4hR0IoKIBbTKxZuyHQzLopb/+0Rvb69uGV7uA==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.12.0"
+        "@prisma/engines": "4.13.0"
       },
       "bin": {
         "prisma": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "typescript": "^5.0.3"
   },
   "prisma": {
-    "seed": "node prisma/seed.js"
+    "seed": "node prisma/seed.tsx"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@headlessui/react": "^1.7.13",
     "@next-auth/prisma-adapter": "^1.0.5",
-    "@prisma/client": "^4.12.0",
+    "@prisma/client": "^4.13.0",
     "@radix-ui/colors": "^0.1.8",
     "@radix-ui/react-avatar": "^1.0.2",
     "@radix-ui/react-dialog": "^1.0.3",
@@ -59,7 +59,7 @@
     "@types/uuid": "^9.0.1",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.21",
-    "prisma": "^4.12.0",
+    "prisma": "^4.13.0",
     "tailwindcss": "^3.2.7",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.3"

--- a/prisma/migrations/20230425221200_remove_member_invitation_model/migration.sql
+++ b/prisma/migrations/20230425221200_remove_member_invitation_model/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the `MemberInvitation` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "MemberInvitation" DROP CONSTRAINT "MemberInvitation_invitedId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "MemberInvitation" DROP CONSTRAINT "MemberInvitation_inviteeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "MemberInvitation" DROP CONSTRAINT "MemberInvitation_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "MemberInvitation" DROP CONSTRAINT "MemberInvitation_projectId_fkey";
+
+-- AlterTable
+ALTER TABLE "Member" ADD COLUMN     "acceptedAt" TIMESTAMP(3),
+ADD COLUMN     "inviteeId" TEXT;
+
+-- DropTable
+DROP TABLE "MemberInvitation";
+
+-- AddForeignKey
+ALTER TABLE "Member" ADD CONSTRAINT "Member_inviteeId_fkey" FOREIGN KEY ("inviteeId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20230425221550_member_has_org_or_project/migration.sql
+++ b/prisma/migrations/20230425221550_member_has_org_or_project/migration.sql
@@ -1,0 +1,3 @@
+-- This is an empty migration.
+
+ALTER TABLE "Member" ADD CONSTRAINT "ensure_userId_or_orgId_exists" CHECK(num_nonnulls(("organizationId"), ("projectId")) = 1);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,16 +45,15 @@ model User {
   comments      Comment[]
   organizations Organization[]
 
-  members Member[]
-
-  memberInvitations        MemberInvitation[] @relation("invited")
-  pendingMemberInvitations MemberInvitation[] @relation("invites")
+  members        Member[] @relation("invites")
+  membersInvited Member[] @relation("invited")
 }
 
 model Organization {
   id String @id @default(cuid())
 
-  name String @unique
+  namespace Namespace?
+  name      String     @unique
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -62,10 +61,7 @@ model Organization {
   userId String
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  namespace Namespace?
-
-  members          Member[]
-  MemberInvitation MemberInvitation[]
+  members Member[]
 }
 
 // Note: 20230319212545_namespace_has_atleast_one_org_or_user:
@@ -83,38 +79,20 @@ model Namespace {
   projects Project[]
 }
 
-model MemberInvitation {
-  id String @id @default(cuid())
-
-  role      OrganizationRole @default(User)
-  createdAt DateTime         @default(now())
-
-  // The user that's being invited
-  invitedId   String
-  invitedUser User   @relation("invited", fields: [invitedId], references: [id])
-
-  // The user that's inviting another user
-  inviteeId   String
-  inviteeUser User   @relation("invites", fields: [inviteeId], references: [id])
-
-  organizationId String?
-  organization   Organization? @relation(fields: [organizationId], references: [id])
-
-  projectId String?
-  project   Project? @relation(fields: [projectId], references: [id])
-
-  @@unique([invitedId, organizationId])
-  @@unique([invitedId, projectId])
-}
-
 model Member {
   id String @id @default(cuid())
 
-  role      OrganizationRole
-  createdAt DateTime         @default(now())
+  role       OrganizationRole
+  createdAt  DateTime         @default(now())
+  acceptedAt DateTime?
 
+  // The user that's being invited
   userId String
-  user   User   @relation(fields: [userId], references: [id])
+  user   User   @relation("invites", fields: [userId], references: [id])
+
+  // The user that's inviting another user
+  inviteeId   String?
+  inviteeUser User?   @relation("invited", fields: [inviteeId], references: [id])
 
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
@@ -141,8 +119,6 @@ model Project {
   members Member[]
   issues  Issue[]
   labels  Label[]
-
-  MemberInvitation MemberInvitation[]
 
   @@unique([namespaceId, name])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["extendedWhereUnique"]
+  previewFeatures = ["extendedWhereUnique", "jsonProtocol"]
 }
 
 datasource db {
@@ -107,10 +107,6 @@ model MemberInvitation {
   @@unique([invitedId, projectId])
 }
 
-// TODO: This is likely going to be a major change.
-// Essentially we want to merge the OrganizationMember table and transform it into a generic Member table (like below)
-// This allows us to have Members for both an Organization and a Project
-// This will be a slow merged as we need to go throughout the code and change things.
 model Member {
   id String @id @default(cuid())
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,8 @@ model Namespace {
   projects Project[]
 }
 
+// Note: 20230425221550_member_has_org_or_project:
+// This ensures that 'userId' or 'projectId' must be set. A row with both fields set or non set cannot exsist in the table.
 model Member {
   id String @id @default(cuid())
 

--- a/prisma/seed.tsx
+++ b/prisma/seed.tsx
@@ -2,10 +2,9 @@ const { PrismaClient } = require("@prisma/client")
 const prisma = new PrismaClient()
 
 async function main() {
-  // TODO: OrganizationSettings, Comments
 
   // Clear the database
-  await prisma.$queryRaw`TRUNCATE "User", "Account", "Session", "UserSettings", "Organization", "Namespace", "Issue", "Comment", "Project", "Label", "_IssueToLabel", "Member", "MemberInvitation";`
+  await prisma.$queryRaw`TRUNCATE "User", "Account", "Session", "UserSettings", "Organization", "Namespace", "Issue", "Comment", "Project", "Label", "_IssueToLabel", "Member";`
 
   // Users
   const alice = await prisma.user.upsert({
@@ -73,7 +72,7 @@ async function main() {
         name: "AliceOrg",
         userId: alice.id,
         members: {
-          create:[
+          create: [
             { userId: alice.id, role: "Owner" },
             { userId: jim.id, role: "User" }
           ]
@@ -88,18 +87,18 @@ async function main() {
   ])
 
   //MemberInvitation
-  const [deleteInvites, newInvite] = await prisma.$transaction([
-    prisma.memberInvitation.deleteMany({
-      where: { organizationId: aliceOrg.id }
-    }),
-    prisma.memberInvitation.create({
-      data: {
-        invitedId: bob.id,
-        inviteeId: alice.id,
-        organizationId: aliceOrg.id
-      }
-    })
-  ])
+  // const [deleteInvites, newInvite] = await prisma.$transaction([
+  //   prisma.memberInvitation.deleteMany({
+  //     where: { organizationId: aliceOrg.id }
+  //   }),
+  //   prisma.memberInvitation.create({
+  //     data: {
+  //       invitedId: bob.id,
+  //       inviteeId: alice.id,
+  //       organizationId: aliceOrg.id
+  //     }
+  //   })
+  // ])
 
   // Get all namespaces
   const [aliceNamespace, bobNamespace, jimNamespace, aliceOrgNamespace] =
@@ -162,17 +161,17 @@ async function main() {
       namespaceId: aliceOrgNamespace.id,
       labels: {
         create: [
-          { name: "Bug", description: "Bug description", color: "rgb" }, // TODO: Change to proper RGB value
+          { name: "Bug", description: "Bug description", color: "392029" },
           {
             name: "Documentation",
             description: "Documentation description",
-            color: "rgb"
-          }, // TODO: Change to proper RGB value
+            color: "122b40"
+          },
           {
             name: "Duplicate",
             description: "Duplicate description",
-            color: "rgb"
-          } // TODO: Change to proper RGB value
+            color: "373c43"
+          }
         ]
       }
     }
@@ -186,17 +185,17 @@ async function main() {
       namespaceId: bobNamespace.id,
       labels: {
         create: [
-          { name: "Bug", description: "Bug description", color: "rgb" }, // TODO: Change to proper RGB value
+          { name: "Bug", description: "Bug description", color: "392029" },
           {
             name: "Documentation",
             description: "Documentation description",
-            color: "rgb"
-          }, // TODO: Change to proper RGB value
+            color: "122b40"
+          },
           {
             name: "Duplicate",
             description: "Duplicate description",
-            color: "rgb"
-          } // TODO: Change to proper RGB value
+            color: "373c43"
+          }
         ]
       }
     }
@@ -257,8 +256,6 @@ async function main() {
     }
   })
 
-  console.log("aliceOrg:")
-  console.log(aliceOrg)
   console.log()
 }
 


### PR DESCRIPTION
Removes the 'MemberInvitation' model instead of just having the Member model. This change saves some space and makes querying easier when members and invitations are involved. From now on to check if a User is part of a Project or Organization, you only need to check if the 'acceptedAt' field in the Member model is set. If the value is null, then the invite is still pending.